### PR TITLE
Support HTML Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Start the dump server by calling the artisan command:
 php artisan dump-server
 ```
 
+You can set the output format to HTML using the `--format` option:
+
+```bash
+php artisan dump-server --format=html > dump.html
+```
+
 And then you can, as you are used to, put `dump` calls in your methods. But instead of dumping the output in your current HTTP request, they will be dumped in the artisan command.
 This is very useful, when you want to dump data from API requests, without having to deal with HTTP errors.
 


### PR DESCRIPTION
This PR updates the console to support multiple descriptor formats (`cli` and `html`) so that you can pipe output to an HTML file:

```
php artisan dump-server --format=html > dump.html
```

Screenshot:

![image](https://user-images.githubusercontent.com/177773/42544924-7a652ee2-8469-11e8-9833-70902ede0e43.png)
