### PR TITLE
Fix fatal error with --format=html when using a closure

### DIFF
--- a/src/RequestContextProvider.php
+++ b/src/RequestContextProvider.php
@@ -26,15 +26,21 @@ class RequestContextProvider implements ContextProviderInterface
         if (null === $this->currentRequest) {
             return null;
         }
+
         $controller = null;
+
         if ($route = $this->currentRequest->route()) {
             $controller = $route->controller;
+
+            if (! $controller && ! is_string($route->action['uses'])) {
+                $controller = $route->action['uses'];
+            }
         }
 
         return array(
             'uri' => $this->currentRequest->getUri(),
             'method' => $this->currentRequest->getMethod(),
-            'controller' => $controller ? $this->cloner->cloneVar(class_basename($this->currentRequest->route()->controller)) : $controller,
+            'controller' => $controller ? $this->cloner->cloneVar(class_basename($controller)) : $controller,
             'identifier' => spl_object_hash($this->currentRequest),
         );
     }


### PR DESCRIPTION
Check to see if the controller isn't defined and set it as the route's
closure. The check uses the same logic as the `Route` class to determine
if the route defines a controller action.

Fixes #9
<hr>
Symfony uses controllers for all route definitions (as far as I know) so the concept of a controller is expected. When the route is a closure the controller will be called "Closure" in the output:

<img width="485" alt="screen shot 2018-07-16 at 4 38 23 pm" src="https://user-images.githubusercontent.com/177773/42789035-c8ae96d0-8917-11e8-8a01-2ace7431dee7.png">

![screen shot 2018-07-16 at 4 37 47 pm](https://user-images.githubusercontent.com/177773/42789044-da657baa-8917-11e8-9221-77637d7f99a5.png)