### PR TITLE
fixed lumen usage b/c of missing config_path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,10 @@
     "autoload": {
         "psr-4": {
             "BeyondCode\\DumpServer\\": "src"
-        }
+        },
+        "files": [
+            "helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/helpers.php
+++ b/helpers.php
@@ -3,11 +3,13 @@ if (!function_exists('config_path')) {
     /**
      * Get the configuration path.
      *
+     * This is a polyfill for the missing shorthand function in lumen.
+     *
      * @param  string $path
      * @return string
      */
     function config_path($path = '')
     {
-        return app()->basePath() . DIRECTORY_SEPARATOR . 'config' . ($path ? DIRECTORY_SEPARATOR . $path : $path);
+        return app()->basePath('config') . ($path ? DIRECTORY_SEPARATOR . $path : $path);
     }
 }

--- a/helpers.php
+++ b/helpers.php
@@ -1,0 +1,13 @@
+<?php
+if (!function_exists('config_path')) {
+    /**
+     * Get the configuration path.
+     *
+     * @param  string $path
+     * @return string
+     */
+    function config_path($path = '')
+    {
+        return app()->basePath() . DIRECTORY_SEPARATOR . 'config' . ($path ? DIRECTORY_SEPARATOR . $path : $path);
+    }
+}

--- a/src/DumpServerCommand.php
+++ b/src/DumpServerCommand.php
@@ -27,7 +27,7 @@ class DumpServerCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Start the dump server to collect dump information.';
+    protected $description = 'Start the dump server to collect dump information';
 
     /** @var DumpServer  */
     private $server;


### PR DESCRIPTION
exception b/c of missing shorthand method:
```
In DumpServerServiceProvider.php line 21:
                                                                  
  Call to undefined function BeyondCode\DumpServer\config_path() 
```



also no dot on the end:
```
  clear-compiled            Remove the compiled class file
  dump-server               Start the dump server to collect dump information.
  help                      Displays help for a command
  list                      Lists commands
  migrate                   Run the database migrations
```