### PR TITLE
Make the command easy to extend.

### DIFF
--- a/src/DumpServerCommand.php
+++ b/src/DumpServerCommand.php
@@ -78,7 +78,22 @@ class DumpServerCommand extends Command
         $errorIo->comment('Quit the server with CONTROL-C.');
 
         $this->server->listen(function (Data $data, array $context, int $clientId) use ($descriptor, $io) {
+            $this->share($data, $context, $clientId);
             $descriptor->describe($io, $data, $context, $clientId);
         });
+    }
+
+    /**
+     * Share the contents of the dump.
+     *
+     * @param  \Symfony\Component\VarDumper\Cloner\Data  $data
+     * @param  array  $context
+     * @param  int  $clientId
+     *
+     * @return void
+     */
+    protected function share(Data $data, array $context, int $clientId)
+    {
+        //
     }
 }

--- a/src/DumpServerCommand.php
+++ b/src/DumpServerCommand.php
@@ -78,8 +78,8 @@ class DumpServerCommand extends Command
         $errorIo->comment('Quit the server with CONTROL-C.');
 
         $this->server->listen(function (Data $data, array $context, int $clientId) use ($descriptor, $io) {
-            $this->share($data, $context, $clientId);
             $descriptor->describe($io, $data, $context, $clientId);
+            $this->share($data, $context, $clientId);
         });
     }
 

--- a/src/DumpServerCommand.php
+++ b/src/DumpServerCommand.php
@@ -34,7 +34,7 @@ class DumpServerCommand extends Command
      *
      * @var \Symfony\Component\VarDumper\Server\DumpServer
      */
-    private $server;
+    protected $server;
 
     /**
      * DumpServerCommand constructor.


### PR DESCRIPTION
I'm working on a project where I need to be able to customize what is happening inside ```$server->listen()```. I'd still like to be able to use this package instead of creating a completely separate command.

I've simply added a protected method to be used in the "listen" closure. The command can easily be overwritten in a child class that extends the command.

```php
    public function handle()
    {
        // ..
        $this->server->listen(function (Data $data, array $context, int $clientId) use ($descriptor, $io) {
            $descriptor->describe($io, $data, $context, $clientId);
            $this->share($data, $context, $clientId);
        });
    }

    protected function share(Data $data, array $context, int $clientId)
    {
        //
    }
```

If there is a better approach or a better method name, feel free to change. 
If you don't like the idea at all, feel free to close.

Many thanks!