### PR TITLE
allow the var dumper host to be env based

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -4,5 +4,5 @@ return [
     /*
      * The host to use when listening for debug server connections.
      */
-    'host' => 'tcp://127.0.0.1:9912',
+    'host' => env('DUMP_SERVER_HOST', 'tcp://127.0.0.1:9912'),
 ];


### PR DESCRIPTION
This would allow users to configure the dump server host in their env file without having to publish the config and maintening it in their code base. 

they would just have to add the extra env var on their server or on their .env files

i used the same env var name than the one symfony uses for the var dumper