### PR TITLE
[Update] Updated the Symfony version of the Dumper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0",
         "illuminate/http": "5.6.*|5.7.*|5.8.*|^6.0",
         "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0",
-        "symfony/var-dumper": "^4.1.1"
+        "symfony/var-dumper": "^5.0"
     },
     "require-dev": {
         "larapack/dd": "^1.0",


### PR DESCRIPTION
As Symfony 5.0 just came out we could update this packages as well.

There aren't really tests in the package, so let me know if stuff broke.
I'll gladly fix it.

#SymfonyHackday