### PR TITLE
Fixing dump not working on windows wsl, when trying to dump on page bug:

### DIFF
--- a/src/Dumper.php
+++ b/src/Dumper.php
@@ -38,10 +38,10 @@ class Dumper
         if (class_exists(CliDumper::class)) {
             $data = (new VarCloner)->cloneVar($value);
 
-            if ($this->connection === null || $this->connection->write($data) === false) {
+//            if ($this->connection === null || $this->connection->write($data) === false) {
                 $dumper = in_array(PHP_SAPI, ['cli', 'phpdbg']) ? new CliDumper : new HtmlDumper;
                 $dumper->dump($data);
-            }
+//            }
         } else {
             var_dump($value);
         }


### PR DESCRIPTION
This only fixes the dump on page.

Not sure if this causes any side effects as there weren't any tests to run.
I am using windows 10 pro wsl (ubuntu 18.04lts) with valet for linux and occasionally the laravel dump stops working - both(the cli and on page).

The only thing that helps it work again for a while is restarting the OS.

restarting php7.4-fpm, nginx, valet, clearing composer dump or clearing cache... Nothing works.