### PR TITLE
[Feature] Support custom BeyondCode\DumpServer\Dumper binding

### DIFF
--- a/src/DumpServerServiceProvider.php
+++ b/src/DumpServerServiceProvider.php
@@ -49,8 +49,11 @@ class DumpServerServiceProvider extends ServiceProvider
             'source' => new SourceContextProvider('utf-8', base_path()),
         ]);
 
-        VarDumper::setHandler(function ($var) use ($connection) {
-            (new Dumper($connection))->dump($var);
+        $this->app->when(Dumper::class)->needs('$connection')->give($connection);
+        $app = $this->app;
+
+        VarDumper::setHandler(function ($var) use ($app) {
+            $app->make(Dumper::class)->dump($var);
         });
     }
 }

--- a/src/Dumper.php
+++ b/src/Dumper.php
@@ -36,7 +36,7 @@ class Dumper
     public function dump($value)
     {
         if (class_exists(CliDumper::class)) {
-            $data = (new VarCloner)->cloneVar($value);
+            $data = $this->createVarCloner()->cloneVar($value);
 
             if ($this->connection === null || $this->connection->write($data) === false) {
                 $dumper = in_array(PHP_SAPI, ['cli', 'phpdbg']) ? new CliDumper : new HtmlDumper;
@@ -45,5 +45,13 @@ class Dumper
         } else {
             var_dump($value);
         }
+    }
+
+    /**
+     * @return VarCloner
+     */
+    protected function createVarCloner(): VarCloner
+    {
+        return new VarCloner();
     }
 }


### PR DESCRIPTION
### Use-Case

We want to be add a custom caster for `Illuminate\Foundation\Application` since it tends to be rather noisy. In order to do that one would need to configure te `Symfony\Component\VarDumper\Cloner\VarCloner`, but there is currently no way to do that cleanly.

### Proposal

Allow applications to optionally override what `Dumper` to use. This is the easiest, backwards-compatible mechanism I was able to come up with so far:

```php

namespace App\Debug

use BeyondCode\DumpServer\Dumper as BaseDumper
use Symfony\Component\VarDumper\Cloner\VarCloner;

// My custom caster.
class AppCaster
{
    public static function castApplication($obj, array $array, Stub $stub, $isNested, $level = 0)
    {
          // Hide noisy contents of Illuminate\Foundation\Application instance if it's nested in what is being dumped.
          return $isNested ? [] : $array; 
    }
}

class Dumper extends BaseDumper
{
     protected function createVarCloner(): VarCloner
     {
           $cloner = parent::createVarCloner();
           // Register my custom caster:
           $cloner->addCasters([
                'Illuminate\Foundation\Application' => ['App\Debug\AppCaster', 'castApplication'],
            ]);
            return $cloner;
     }
}
```

With this patch, I'd be able to sub it in cleanly from my service provider:

```php

use BeyondCode\DumpServer\Dumper;
use App\Debug\Dumper as MyDumper;

public function register()
{
     // Use my custom Dumper:
     if (class_exists(Dumper::class)) {
           $this->app->bind(Dumper:class, MyDumper::class);
     }
}
```

---

If you think this patch is acceptable, I'll be happy to add some test coverage.