### PR TITLE
[bugfix] Fix setting correct connection on dumper instance

### DIFF
--- a/src/DumpServerServiceProvider.php
+++ b/src/DumpServerServiceProvider.php
@@ -49,9 +49,8 @@ class DumpServerServiceProvider extends ServiceProvider
             'source' => new SourceContextProvider('utf-8', base_path()),
         ]);
 
-        $app = $this->app;
-        VarDumper::setHandler(function ($var) use ($app, $connection) {
-            $app->makeWith(Dumper::class, ['connection' => $connection])->dump($var);
+        VarDumper::setHandler(function ($var) use ($connection) {
+            $this->app->makeWith(Dumper::class, ['connection' => $connection])->dump($var);
         });
     }
 }

--- a/src/DumpServerServiceProvider.php
+++ b/src/DumpServerServiceProvider.php
@@ -49,11 +49,9 @@ class DumpServerServiceProvider extends ServiceProvider
             'source' => new SourceContextProvider('utf-8', base_path()),
         ]);
 
-        $this->app->when(Dumper::class)->needs('$connection')->give($connection);
         $app = $this->app;
-
-        VarDumper::setHandler(function ($var) use ($app) {
-            $app->make(Dumper::class)->dump($var);
+        VarDumper::setHandler(function ($var) use ($app, $connection) {
+            $app->makeWith(Dumper::class, ['connection' => $connection])->dump($var);
         });
     }
 }


### PR DESCRIPTION
https://github.com/beyondcode/laravel-dump-server/pull/70 introduces a bug where the connection would not be set on the `Dumper` class. This PR resolves that and also allows for custom bindings.