### PR TITLE
Mark spatie/laravel-ray as conflicting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
         "larapack/dd": "^1.0",
         "phpunit/phpunit": "^7.0|^9.3"
     },
+    "conflict": {
+        "spatie/laravel-ray": "*"
+    },
     "autoload": {
         "psr-4": {
             "BeyondCode\\DumpServer\\": "src"


### PR DESCRIPTION
Fixes #78.

Our package is discovered first, so our `VarDumper::$handler` is always overwritten by spatie/laravel-ray.

This could be fixed by `symfony/var-dumper` supporting multiple handlers.