### PR TITLE
Laravel 9 and Symfony Var-Dumper 6 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-dump-server` will be documented in this file
 
+## Unreleased
+
+- laravel 9 support
+
 ## 1.0.0 - 2018-07-09
 
 - initial release

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
-        "illuminate/http": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
-        "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
-        "symfony/var-dumper": "^5.0"
+        "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/http": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0",
+        "symfony/var-dumper": "^5.0|^6.0"
     },
     "require-dev": {
         "larapack/dd": "^1.0",

--- a/src/DumpServerCommand.php
+++ b/src/DumpServerCommand.php
@@ -3,7 +3,6 @@
 namespace BeyondCode\DumpServer;
 
 use Illuminate\Console\Command;
-
 use InvalidArgumentException;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\Console\Style\SymfonyStyle;


### PR DESCRIPTION
This `should` provide Laravel 9, and thus, Symfony 6 support. The Var Dumper for Symfony appears to be backward compatible between 5.x and 6.x

Issue: #81 