### PR TITLE
add support for Laravel 9 dumpWithSource

### DIFF
--- a/src/FallbackDumper.php
+++ b/src/FallbackDumper.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace BeyondCode\DumpServer;
+
+use Illuminate\Foundation\Console\CliDumper as LaravelCliDumper;
+use Illuminate\Foundation\Http\HtmlDumper as LaravelHtmlDumper;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Dumper\CliDumper as SymfonyCliDumper;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper as SymfonyHtmlDumper;
+
+class FallbackDumper
+{
+    /**
+     * The base path of the application.
+     *
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * The compiled view path for the application.
+     *
+     * @var string
+     */
+    protected $compiledViewPath;
+
+    /**
+     * FallbackDumper constructor.
+     *
+     * @param  string  $basePath
+     * @param  string  $compiledViewPath
+     * @return void
+     */
+    public function __construct(string $basePath, string $compiledViewPath)
+    {
+        $this->basePath = $basePath;
+        $this->compiledViewPath = $compiledViewPath;
+    }
+
+    /**
+     * Dump a value with elegance.
+     *
+     * @param  Data  $data
+     * @return void
+     */
+    public function dump(Data $data)
+    {
+        if (class_exists(LaravelCliDumper::class)) {
+            // Laravel 9+
+            $dumper = in_array(PHP_SAPI, ['cli', 'phpdbg'])
+                ? new LaravelCliDumper(new ConsoleOutput, $this->basePath, $this->compiledViewPath)
+                : new LaravelHtmlDumper($this->basePath, $this->compiledViewPath);
+
+            $dumper->dumpWithSource($data);
+        } else {
+            $dumper = in_array(PHP_SAPI, ['cli', 'phpdbg'])
+                ? new SymfonyCliDumper
+                : new SymfonyHtmlDumper;
+
+            $dumper->dump($data);
+        }
+    }
+}


### PR DESCRIPTION
Laravel 9 added source file & line number https://github.com/laravel/framework/pull/44211 to the dump/dd output, but laravel-dump-server is not compatible with this feature.

The goal of this PR is to fix this by using Laravels dumper as fallback if the dump-server is not running.

This PR should not introduce any breaking changes and it also keeps support for older Laravel versions.

**before this PR**

<img width="454" src="https://github.com/user-attachments/assets/c33db7b5-1fd1-4807-9f86-09dac02f1441">

**after this PR**

<img width="729" src="https://github.com/user-attachments/assets/66a9b2ef-0748-4dc3-9afe-5d6465652076">
