### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/Dumper.php
+++ b/src/Dumper.php
@@ -22,7 +22,7 @@ class Dumper
      * @param  \Symfony\Component\VarDumper\Server\Connection|null  $connection
      * @return void
      */
-    public function __construct(Connection $connection = null)
+    public function __construct(?Connection $connection = null)
     {
         $this->connection = $connection;
     }

--- a/src/RequestContextProvider.php
+++ b/src/RequestContextProvider.php
@@ -28,7 +28,7 @@ class RequestContextProvider implements ContextProviderInterface
      * @param  \Illuminate\Http\Request|null  $currentRequest
      * @return void
      */
-    public function __construct(Request $currentRequest = null)
+    public function __construct(?Request $currentRequest = null)
     {
         $this->currentRequest = $currentRequest;
         $this->cloner = new VarCloner;


### PR DESCRIPTION
This PR removes implicitly nullable parameters because these result in deprecation warnings for PHP 8.4.

https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter