### PR TITLE
Support Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     },
     "require": {
         "php": ">=7.2.5",
-        "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/http": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/http": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "symfony/var-dumper": "^5.0|^6.0|^7.0"
     },
     "require-dev": {
@@ -49,6 +49,8 @@
     "config": {
         "sort-packages": true
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,6 @@
     "config": {
         "sort-packages": true
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "extra": {
         "laravel": {
             "providers": [


### PR DESCRIPTION
This pull request adds support for Laravel 12.

This repository does not appear to have CI set up, but I checked the test path in my local environment:

<img width="718" alt="Test-with-Laravel-12" src="https://github.com/user-attachments/assets/1a865860-cd95-4e3c-977e-dc7c02a7d7e1" />

~~At this time, Laravel 12 requires the dev version to be installed, so I added `"minimum-stability": "dev"` to composer.json. At the same time, I also added `"prefer-stable": true`, so that no libraries other than Laravel will have dev versions added.~~
Laravel 12 has been released and it is no longer necessary, so I have reverted back to the original.